### PR TITLE
Allow setting on timezone for formatted datetimes.

### DIFF
--- a/src/cell.js
+++ b/src/cell.js
@@ -83,6 +83,7 @@ class Cell extends React.Component {
               onClick={this.props.onEventClick}
               onDrop={this.props.onEventDrop}
               dropMargin={this.props.dropMargin}
+              timezone={this.props.timezone}
               {...event}
             />
           )

--- a/src/event.js
+++ b/src/event.js
@@ -96,15 +96,22 @@ class Event extends React.Component {
       notes = (<p><em>{this.props.eventData.attributes.notes}</em></p>)
     }
 
+    const moment_begins = moment(begins, 'x')
+    const moment_ends = moment(ends, 'x')
+    if (this.props.timezone) {
+      moment_begins.tz(this.props.timezone)
+      moment_ends.tz(this.props.timezone)
+    }
+
     let event = (
       <div
         className="rbucks-content"
         style={this.props.style}
       >
-        <div className="rbucks-label">
-          {moment(begins, 'x').format(timeFormat)} - {moment(ends, 'x').format(timeFormat)}
-        </div>
-        <div className="title">{this.props.title}</div>
+        <p className="rbucks-label">
+          {moment_begins.format(timeFormat)} - {moment_ends.format(timeFormat)}
+        </p>
+        <p>{this.props.title}</p>
         {location}
         {notes}
       </div>

--- a/src/row.js
+++ b/src/row.js
@@ -78,6 +78,7 @@ class Row extends React.Component {
               onEventDrop={this.props.onEventDrop}
               showActiveTime={this.props.showActiveTime}
               dropMargin={this.props.dropMargin}
+              timezone={this.props.timezone}
             />
           )
         })}


### PR DESCRIPTION
Currently, this package accepts timestamps, localising them based on moment's default settings (taking browser timezone).
This is nice, however in applications that allow users to set their own timezone in preferences (such as our appointment scheduler), the timezone used should be one that's passed in via props. Browser's timezone should be used only as a fallback.

I've made the starts for this in this the PR here; need to still pass the timezone down from the top level (or feed in via some provider)..